### PR TITLE
fix(ranges): allow dollar signs

### DIFF
--- a/formulas/helpers.js
+++ b/formulas/helpers.js
@@ -397,7 +397,7 @@ const Address = {
     },
 
     columnNameToNumber: (columnName) => {
-        columnName = columnName.toUpperCase();
+        columnName = columnName.replace("$","").toUpperCase();
         const len = columnName.length;
         let number = 0;
         for (let i = 0; i < len; i++) {

--- a/grammar/dependency/utils.js
+++ b/grammar/dependency/utils.js
@@ -255,7 +255,7 @@ class Utils {
      * @return {number}
      */
     toNumber(number) {
-        return Number(number);
+        return Number(number.replace("$",""));
     }
 
     /**

--- a/grammar/lexing.js
+++ b/grammar/lexing.js
@@ -59,7 +59,7 @@ const Cell = createToken({
 
 const Number = createToken({
     name: 'Number',
-    pattern: /[0-9]+[.]?[0-9]*([eE][+\-][0-9]+)?/
+    pattern: /[$]?[0-9]+[.]?[0-9]*([eE][+\-][0-9]+)?/
 });
 
 const Boolean = createToken({
@@ -72,7 +72,6 @@ const Column = createToken({
     pattern: /[$]?[A-Za-z]{1,3}/,
     longer_alt: Name
 });
-
 
 /**
  * Symbols and operators

--- a/grammar/utils.js
+++ b/grammar/utils.js
@@ -354,7 +354,7 @@ class Utils {
      * @return {number}
      */
     toNumber(number) {
-        return Number(number);
+        return Number(number.replace("$",""));
     }
 
     /**

--- a/test/grammar/depParser.js
+++ b/test/grammar/depParser.js
@@ -48,6 +48,22 @@ describe('Dependency parser', () => {
         expect(actual).to.deep.eq([{sheet: 'Sheet1', from: {row: 1, col: 1}, to: {row: 3, col: 16384}}]);
     });
 
+    it('should parse special ranges', () => {
+        actual = depParser.parse('$A:$C', position);
+        expect(actual).to.deep.eq([{sheet: 'Sheet1', from: {row: 1, col: 1}, to: {row: 1048576, col: 3}}]);
+        actual = depParser.parse('A:$C', position);
+        expect(actual).to.deep.eq([{sheet: 'Sheet1', from: {row: 1, col: 1}, to: {row: 1048576, col: 3}}]);
+        actual = depParser.parse('$A:C', position);
+        expect(actual).to.deep.eq([{sheet: 'Sheet1', from: {row: 1, col: 1}, to: {row: 1048576, col: 3}}]);
+
+        actual = depParser.parse('$1:$3', position);
+        expect(actual).to.deep.eq([{sheet: 'Sheet1', from: {row: 1, col: 1}, to: {row: 3, col: 16384}}]);
+        actual = depParser.parse('1:$3', position);
+        expect(actual).to.deep.eq([{sheet: 'Sheet1', from: {row: 1, col: 1}, to: {row: 3, col: 16384}}]);
+        actual = depParser.parse('$1:3', position);
+        expect(actual).to.deep.eq([{sheet: 'Sheet1', from: {row: 1, col: 1}, to: {row: 3, col: 16384}}]);
+    });
+
     it('should parse variable', function () {
         let actual = depParser.parse('aaaa', position);
         expect(actual).to.deep.eq([{sheet: 'Sheet1', from: {row: 1, col: 1}, to: {row: 2, col: 2}}]);


### PR DESCRIPTION
This PR adds support for ranges like `$A1:$A3` or `$1:$3` I found in an Excel file lately.

I added according unit tests.

Thanks for considering.