### PR TITLE
add text formula substitute without occurrences

### DIFF
--- a/formulas/functions/text.js
+++ b/formulas/functions/text.js
@@ -292,8 +292,12 @@ const TextFunctions = {
         return TextFunctions.SEARCH(...params)
     },
 
-    SUBSTITUTE: (...params) => {
+    SUBSTITUTE: (text, search_for, replace_with) => {
+        text = H.accept(text, [Types.STRING]);
+        search_for = H.accept(search_for, [Types.STRING]);
+        replace_with = H.accept(replace_with, [Types.STRING]);
 
+        return text.replace(search_for, replace_with);
     },
 
     T: (value) => {

--- a/test/formulas/text/testcase.js
+++ b/test/formulas/text/testcase.js
@@ -140,6 +140,13 @@ module.exports = {
         'SEARCH("c\\b", "abcabcac\\bacb", 6)': 8,
     },
 
+    SUBSTITUTE: {
+        'SUBSTITUTE("Welcome xxx","xxx","FFP")': "Welcome FFP",
+        'SUBSTITUTE("Welcome FFP"," ","")': "WelcomeFFP",
+        'SUBSTITUTE("#%#$%","%#","Hi")': "#Hi$%",
+        'SUBSTITUTE("r r r","r","a")': "a r r",
+    },
+
     T: {
         'T("*_")': "*_",
         'T(19)': "",


### PR DESCRIPTION
https://support.google.com/docs/answer/3094215?hl=en#:~:text=SUBSTITUTE%20can%20be%20used%20to,in%20conjunction%20with%20this%20function.

Implemented to using inbuilt JS function replace which is similar behaviour to substitute. 

Whats not implemented is option occurrences as theres no inbuilt function.